### PR TITLE
use wlanpi-webui `main` instead of `dev`

### DIFF
--- a/packages/extras-buildpkgs/90-wlanpi-webui.conf
+++ b/packages/extras-buildpkgs/90-wlanpi-webui.conf
@@ -1,7 +1,7 @@
 # wlanpi-webui
 local package_name="wlanpi-webui"
 local package_repo="https://github.com/joshschmelzle/wlanpi-webui.git"
-local package_ref="branch:dev"
+local package_ref="branch:main"
 #local package_upstream_version="2.0.2"
 local package_builddeps=""
 local package_install_target="wlanpi-webui"


### PR DESCRIPTION
Please use the "Preview" tab above to view this message if you are seeing this in the new pull request text box.

Please make sure that:

 - pull request is opened to the `master` branch unless you are working on a specfic feature which is developed in a separate branch
 - any changes to kernel configuration files were made by Kconfig menu (build script option `KERNEL_CONFIGURE=yes`) and not by editing configuration files by hand,
 - patch file names don't contain spaces and have less than 40 characters (not counting the `.patch` extension),
 - changes are properly described - what was done exactly and why.

Thanks for contributing! Please remove the text above before opening a pull request.
