### PR TITLE
Enable dynamically assigned DNS nameservers

### DIFF
--- a/userpatches/customize-image.sh
+++ b/userpatches/customize-image.sh
@@ -221,7 +221,7 @@ SetupOtherConfigFiles() {
 	echo "nameserver 8.8.8.8" >> /etc/resolvconf/resolv.conf.d/tail
 
 	display_alert "Enable dynamically assigned DNS nameservers" "" "info"
-	sudo ln -sf /etc/resolvconf/run/resolv.conf /etc/resolv.conf
+	ln -sf /etc/resolvconf/run/resolv.conf /etc/resolv.conf
 
 	display_alert "Add our custom sudoers file" "" "info"
 	copy_overlay /etc/sudoers.d/wlanpidump -o root -g root -m 440

--- a/userpatches/customize-image.sh
+++ b/userpatches/customize-image.sh
@@ -220,6 +220,9 @@ SetupOtherConfigFiles() {
 	display_alert "Set default DNS nameserver on resolveconf template" "" "info"
 	echo "nameserver 8.8.8.8" >> /etc/resolvconf/resolv.conf.d/tail
 
+	display_alert "Enable dynamically assigned DNS nameservers" "" "info"
+	sudo ln -sf /etc/resolvconf/run/resolv.conf /etc/resolv.conf
+
 	display_alert "Add our custom sudoers file" "" "info"
 	copy_overlay /etc/sudoers.d/wlanpidump -o root -g root -m 440
 


### PR DESCRIPTION
Fix for: [https://github.com/WLAN-Pi/v2-migration-docs/issues/95](https://github.com/WLAN-Pi/v2-migration-docs/issues/95)
