### PR TITLE
Move SetupOtherConfigFiles to execute last

### DIFF
--- a/userpatches/customize-image.sh
+++ b/userpatches/customize-image.sh
@@ -26,7 +26,6 @@ Main() {
 	SetDefaultShell
 	AddUserWLANPi
 	SetupRNDIS
-	SetupOtherConfigFiles
 	SetupPipxEnviro
 	InstallPipx
 	InstallSpeedTestPipx
@@ -35,6 +34,7 @@ Main() {
 	SetupCockpit
 	InstallFlaskWebUI
 	SetupOtherServices
+	SetupOtherConfigFiles
 
 } # Main
 


### PR DESCRIPTION
SetupOtherConfigFiles makes changes to resolv.conf which broke DNS for pip, moving to execute last to avoid this issue
