### PR TITLE
copy profiler config to /etc/profiler2

### DIFF
--- a/userpatches/customize-image.sh
+++ b/userpatches/customize-image.sh
@@ -79,6 +79,7 @@ InstallProfilerPipx() {
 	
 	pipx install git+https://github.com/joshschmelzle/profiler2.git@main#egg=profiler2
 	copy_overlay /lib/systemd/system/profiler.service -o root -g root -m 644
+	copy_overlay /etc/profiler2/config.ini -o root -g root -m 644
 }
 
 SetupCockpit() {

--- a/userpatches/overlay/etc/profiler2/config.ini
+++ b/userpatches/overlay/etc/profiler2/config.ini
@@ -1,0 +1,36 @@
+#              ___ _ _                        ___ _     
+#  ___ ___ ___|  _|_| |___ ___    ___ ___ ___|  _|_|___ 
+# | . |  _| . |  _| | | -_|  _|  |  _| . |   |  _| | . |
+# |  _|_| |___|_| |_|_|___|_|    |___|___|_|_|_| |_|_  |
+# |_|                                              |___|
+# 
+#
+# following settings change the default values used by the profiler
+# any command-line arguments passed in will override these defaults
+# WARNING: changing section names or keys *will* break the profiler
+
+[GENERAL]
+
+# channel for profiler AP
+channel: 36
+
+# SSID name for profiler AP
+ssid: WLAN Pi
+
+# interface used by profiler AP
+interface: wlan0
+
+# enable or disable 802.11r information elements (True/False)
+ft_disabled: False
+
+# enable or disable 802.11ax information elements (True/False)
+he_disabled: False
+
+# disables beacons and instead only listens for assoc req frames (True/False)
+listen_only: False
+
+# use the system's hostname as the profiler AP SSID (True/False)
+hostname_ssid: False
+
+# specify path where results will be placed
+files_path: /var/www/html/profiler


### PR DESCRIPTION
- @wifinigel requested the configuration file for profiler to be at /etc/profiler2/config.ini instead of inside the rather long pipx venv path.
- rationale is we are moving in the direction of putting config files in /etc for the different utils/apps