### PR TITLE
Add networkinfo service and configure arp_ignore

### DIFF
--- a/userpatches/customize-image.sh
+++ b/userpatches/customize-image.sh
@@ -204,9 +204,9 @@ SetupOtherServices() {
 	copy_overlay /lib/systemd/system/iperf2.service -o root -g root -m 644
 	copy_overlay /lib/systemd/system/iperf2-udp.service -o root -g root -m 644
 
-        display_alert "Setup service" "networkinfo" "info"
-        copy_overlay /lib/systemd/system/networkinfo.service -o root -g root -m 644
-        systemctl enable networkinfo
+	display_alert "Setup service" "networkinfo" "info"
+	copy_overlay /lib/systemd/system/networkinfo.service -o root -g root -m 644
+	systemctl enable networkinfo
 
 	display_alert "Disable service for OTG serial" "serial-getty" "info"
 	if [ $LINUXFAMILY == sunxi* ]; then

--- a/userpatches/customize-image.sh
+++ b/userpatches/customize-image.sh
@@ -254,6 +254,9 @@ SetupOtherConfigFiles() {
 	display_alert "Copy config file" "network/interfaces" "info"
 	copy_overlay /etc/network/interfaces -o root -g root -m 644
 
+	display_alert "Configure arp_ignore" "network/arp" "info"
+	echo "net.ipv4.conf.eth0.arp_ignore = 1" >> /etc/sysctl.conf
+
 	display_alert "Copy config file" "ifplugd" "info"
 	copy_overlay /etc/default/ifplugd -o root -g root -m 644
 

--- a/userpatches/customize-image.sh
+++ b/userpatches/customize-image.sh
@@ -204,6 +204,10 @@ SetupOtherServices() {
 	copy_overlay /lib/systemd/system/iperf2.service -o root -g root -m 644
 	copy_overlay /lib/systemd/system/iperf2-udp.service -o root -g root -m 644
 
+        display_alert "Setup service" "networkinfo" "info"
+        copy_overlay /lib/systemd/system/networkinfo.service -o root -g root -m 644
+        systemctl enable networkinfo
+
 	display_alert "Disable service for OTG serial" "serial-getty" "info"
 	if [ $LINUXFAMILY == sunxi* ]; then
 		systemctl disable serial-getty@ttyS1

--- a/userpatches/overlay/lib/systemd/system/networkinfo.service
+++ b/userpatches/overlay/lib/systemd/system/networkinfo.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Networkinfo daemon responsible for collecting network details of the WLAN Pi
+
+[Service]
+ExecStart=/usr/share/fpms/BakeBit/Software/Python/scripts/networkinfo/networkinfo.sh
+WorkingDirectory=/usr/share/fpms/BakeBit/Software/Python/scripts/networkinfo
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Networkinfo is now a service which can run independently from FPMS. This is especially useful on boards without a display hat, where FMPS currently crashes on boot and networkinfo will not start today.