### PR TITLE
Set default WLAN Pi mode to classic

### DIFF
--- a/userpatches/customize-image.sh
+++ b/userpatches/customize-image.sh
@@ -270,7 +270,7 @@ SetupOtherConfigFiles() {
 	copy_overlay /etc/default/crda -o root -g root -m 644
 
 	display_alert "Copy state file" "WLAN Pi Mode" "info"
-        copy_overlay /etc/wlanpi-state -o root -g root -m 644
+	copy_overlay /etc/wlanpi-state -o root -g root -m 644
 }
 
 InstallMongoDB() {

--- a/userpatches/customize-image.sh
+++ b/userpatches/customize-image.sh
@@ -265,9 +265,12 @@ SetupOtherConfigFiles() {
 
 	display_alert "Change default systemd boot target" "multi-user.target" "info"
 	systemctl set-default multi-user.target
-	
+
 	display_alert "Copy config file" "RF Central Regulatory Domain Agent" "info"
-	copy_overlay /etc/default/crda -o root -g root -m 644	
+	copy_overlay /etc/default/crda -o root -g root -m 644
+
+	display_alert "Copy state file" "WLAN Pi Mode" "info"
+        copy_overlay /etc/wlanpi-state -o root -g root -m 644
 }
 
 InstallMongoDB() {

--- a/userpatches/overlay/etc/wlanpi-state
+++ b/userpatches/overlay/etc/wlanpi-state
@@ -1,0 +1,1 @@
+classic


### PR DESCRIPTION
Set WLAN Pi mode to classic at the first mode. Without this, mode switching will fail on non-NEO2 boards. This is a system component, not directly related to any particular package and builder should be the right place for it.

Tested on Rock Pi E and NEO2.